### PR TITLE
docs: add v0.1.0 release notes

### DIFF
--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,87 +1,246 @@
 # HALF v0.1.0 Release Notes
 
-Release date: 2026-04-24
+Release date: TBD
 
-## Summary
+## English
 
-`v0.1.0` is the first formal public release of HALF.
+`v0.1.0` is the first formal public release of HALF. It establishes the
+project's initial product boundary: HALF is a human-in-the-loop coordination
+console for teams operating multiple AI coding agents across Git-based
+workflows.
 
-This release establishes the core product boundary:
+This release is intended for controlled self-hosted evaluation. It is not a
+production-hardened SaaS platform and does not promise long-term API or data
+model stability yet.
 
-- HALF is a human-in-the-loop multi-agent coordination console
-- it does not directly run external agents on behalf of the user
-- it focuses on prompt generation, Git-based result tracking, task orchestration,
-  and operator-facing workflow visibility
+### What HALF Does
 
-## Included In v0.1.0
+HALF helps an operator coordinate agent-assisted development work without
+turning HALF into an agent runner.
 
-Core capabilities available in this release:
+In this release, HALF can:
 
-- project creation and project-scoped agent coordination
-- plan generation via prompt flow or process templates
-- DAG-based task execution workflow
-- Git-backed result detection using fixed task directories and `result.json`
-- execution summary pages
-- agent availability tracking with subscription expiry and reset windows
-- process template management
-- owner-scoped project and task isolation
-- admin/user role separation
-- Docker Compose deployment path
-- public documentation for architecture, task lifecycle, project structure, and
-  UI principles
+- create projects with project-scoped agent assignments
+- generate DAG-shaped plans through prompt flow or reusable process templates
+- dispatch task prompts for a human operator to copy into external coding agents
+- track task progress through Git-visible outputs and `result.json` completion
+  markers
+- show task, plan, DAG, and execution summary views
+- track agent availability, subscription expiry, and reset windows
+- manage process templates
+- separate admin and regular user roles
+- isolate user-owned projects and tasks
+- run through the documented Docker Compose deployment path
 
-## Not Included In v0.1.0
+### What HALF Deliberately Does Not Do
 
-The following are intentionally out of scope for this release:
+HALF does not directly invoke Claude Code, Codex, Copilot, Kimi, GLM, or other
+external coding agents. It produces prompts, tracks state, and watches Git
+outputs; the actual agent interaction remains under human control.
+
+This release also does not include:
 
 - fully automated agent execution
-- hardened multi-tenant hosting
-- broad compatibility guarantees across all deployment styles
-- mature long-term API stability
-- polished onboarding assets such as screenshots, demo seed data, and short
-  guided demos
+- a hosted multi-tenant SaaS security model
+- broad compatibility guarantees for every Git hosting or deployment shape
+- a stable long-term public API
+- polished onboarding assets such as screenshots, demo seed data, or guided GIFs
+- built-in telemetry or anonymous usage reporting
 
-## Stability Notes
+### Recommended Usage Boundary
 
-HALF remains a `v0.x` project.
+Use `v0.1.0` if you want to evaluate HALF in a self-hosted environment with a
+trusted team and a human operator in the loop.
 
-That means:
+Good fits:
 
-- some interfaces may still change
-- parts of the data model may still evolve
-- operational details may still be refined as real users trial the system
+- single-tenant self-hosted trials
+- teams manually coordinating multiple coding agents
+- workflows where task outputs are committed back to a Git repository
+- early feedback on the product model, task lifecycle, and template ergonomics
 
-Users should treat `v0.1.0` as an early open-source release suitable for
-controlled self-hosted evaluation and feedback, rather than as a finalized
-platform release.
+Poor fits:
 
-## Recommended Usage Boundary
+- untrusted public multi-user hosting
+- replacing Jira, Linear, or a general-purpose project management system
+- fully automated execution without a human operator
+- environments that require stable APIs, formal compatibility guarantees, or
+  hardened enterprise controls
 
-This release is best suited for:
+### Deployment Notes
 
-- self-hosted, single-tenant environments
-- teams or operators coordinating multiple coding agents manually
-- users who want Git-visible task outputs and explicit workflow state
+The primary deployment path is Docker Compose:
 
-This release is not recommended as:
+- start with `README.md`
+- copy `src/.env.example` to `src/.env`
+- set a strong `HALF_SECRET_KEY`
+- set a strong `HALF_ADMIN_PASSWORD`
+- keep `HALF_STRICT_SECURITY=true` unless you have a specific reason to change it
 
-- a generic Jira/Linear replacement
-- a drop-in SaaS product for untrusted users
-- an agent runner that directly automates all execution
+Before exposing HALF beyond localhost, review `SECURITY.md`. HALF is designed
+for trusted self-hosted use and should be placed behind a TLS-terminating reverse
+proxy in real deployments.
 
-## Upgrade / Adoption Notes
+### Documentation Included
 
-If you are trying HALF for the first time:
+The repository includes public documentation for:
 
-- start with the Docker Compose deployment path in `README.md`
-- review `SECURITY.md` before exposing the service beyond localhost
-- treat the current release as a controlled trial rather than a production-hardened platform
+- system architecture and data model overview: `docs/architecture.md`
+- task lifecycle and `result.json` contract: `docs/task-lifecycle.md`
+- source tree organization: `docs/project-structure.md`
+- UI and interaction principles: `docs/ui-style.md`
+- security and deployment boundary: `SECURITY.md`
+- contribution workflow: `CONTRIBUTING.md`
 
-## What Comes Next
+### Known Gaps
 
-The next iterations will prioritize:
+The following gaps are known and intentionally not blocking this first public
+release:
 
-- better onboarding and trialability
-- clearer compatibility expectations
-- stronger release discipline and maintenance signals
-- continued refinement of the human-in-the-loop workflow
+- README screenshots and a short demo GIF are still pending.
+- A first-run demo project / seed dataset is still pending.
+- A clean-environment Quick Start walkthrough still needs a full manual pass.
+- GitHub repository URL validation needs stricter user-facing validation.
+- Some agent availability reset behavior still needs research before it becomes
+  an implementation issue.
+- English i18n is welcome but not yet implemented.
+
+These are tracked as follow-up issues and roadmap items rather than hidden
+release blockers.
+
+### Stability Notes
+
+HALF remains a `v0.x` project. During `v0.x`:
+
+- API fields may change
+- database tables and relationships may evolve
+- task lifecycle details may be refined
+- process template formats may be adjusted
+- documentation and setup guidance may change as real users trial the system
+
+Treat `v0.1.0` as an early public baseline for evaluation, feedback, and
+iteration.
+
+### What's Next
+
+Near-term work after `v0.1.0` focuses on:
+
+- improving first-run onboarding with screenshots, demo data, and clearer setup
+  guidance
+- tightening compatibility and deployment expectations
+- refining project and agent usability
+- expanding contributor-friendly entry points such as documentation and i18n
+- continuing to document design decisions around permissions and workflow
+  boundaries
+
+## 简体中文
+
+`v0.1.0` 是 HALF 的第一个正式公开版本。这个版本确立了项目的初始产品边界：HALF 是一个 human-in-the-loop 的多 AI 编程 Agent 协作控制台，用于帮助团队围绕 Git 工作流协调多个外部编码 Agent。
+
+这个版本适合在受控的自托管环境中试用和评估。它还不是生产级多租户 SaaS 平台，也暂不承诺长期稳定的 API 或数据模型。
+
+### HALF 能做什么
+
+HALF 帮助操作者组织和协调 Agent 辅助开发工作，但不会把自身变成 Agent runner。
+
+在这个版本中，HALF 支持：
+
+- 创建项目并为项目绑定 Agent
+- 通过 prompt flow 或可复用 process template 生成 DAG 计划
+- 生成任务提示词，由人工操作者复制到外部编码 Agent
+- 通过 Git 中的产物和 `result.json` 完成标记跟踪任务进度
+- 展示任务、计划、DAG 和执行摘要页面
+- 跟踪 Agent 可用性、订阅到期时间和重置窗口
+- 管理 process template
+- 区分管理员与普通用户角色
+- 隔离用户自己的项目和任务
+- 通过文档中的 Docker Compose 路径部署运行
+
+### HALF 明确不做什么
+
+HALF 不会直接调用 Claude Code、Codex、Copilot、Kimi、GLM 或其他外部编码 Agent。它负责生成提示词、跟踪状态、观察 Git 产物；真实的 Agent 交互仍由人工控制。
+
+这个版本也不包含：
+
+- 全自动 Agent 执行
+- 托管式多租户 SaaS 安全模型
+- 覆盖所有 Git 托管或部署形态的兼容性承诺
+- 长期稳定的公共 API
+- 完整的 onboarding 素材，例如截图、demo seed 数据或引导 GIF
+- 内置遥测或匿名使用数据上报
+
+### 推荐使用边界
+
+如果你希望在自托管环境中评估 HALF，并且团队是可信的、流程中有人类操作者参与，那么 `v0.1.0` 是合适的试用起点。
+
+适合的场景：
+
+- 单租户自托管试用
+- 团队人工协调多个编码 Agent
+- 任务产出会提交回 Git 仓库的工作流
+- 对产品模型、任务生命周期和模板能力做早期反馈
+
+不适合的场景：
+
+- 面向不可信用户的公开多用户托管
+- 替代 Jira、Linear 或通用项目管理系统
+- 完全无人参与的自动执行
+- 需要稳定 API、正式兼容性承诺或企业级加固能力的环境
+
+### 部署说明
+
+主要部署路径是 Docker Compose：
+
+- 从 `README.md` 开始
+- 复制 `src/.env.example` 为 `src/.env`
+- 设置强 `HALF_SECRET_KEY`
+- 设置强 `HALF_ADMIN_PASSWORD`
+- 除非有明确理由，否则保持 `HALF_STRICT_SECURITY=true`
+
+在把 HALF 暴露到 localhost 之外之前，请先阅读 `SECURITY.md`。HALF 面向可信自托管场景；实际部署时应放在负责 TLS 终止的反向代理之后。
+
+### 已包含的文档
+
+仓库包含以下公开文档：
+
+- 系统架构与数据模型概览：`docs/architecture.md`
+- 任务生命周期与 `result.json` 契约：`docs/task-lifecycle.md`
+- 源码目录组织：`docs/project-structure.md`
+- UI 与交互原则：`docs/ui-style.md`
+- 安全与部署边界：`SECURITY.md`
+- 贡献流程：`CONTRIBUTING.md`
+
+### 已知缺口
+
+以下缺口是已知的，并且不会阻塞这个首个公开版本：
+
+- README 截图和短演示 GIF 仍待补充。
+- 首次启动可浏览的 demo project / seed 数据仍待补充。
+- 干净环境 Quick Start 仍需要完整人工实测。
+- GitHub 仓库 URL 需要更严格、用户可理解的校验。
+- 部分 Agent 可用性重置行为还需要研究后再决定是否进入实现。
+- 英文 i18n 欢迎贡献，但尚未实现。
+
+这些内容会作为后续 issue 和 roadmap 项继续推进，而不是隐藏的 release blocker。
+
+### 稳定性说明
+
+HALF 仍处于 `v0.x` 阶段。在 `v0.x` 期间：
+
+- API 字段可能变化
+- 数据库表和关系可能演进
+- 任务生命周期细节可能继续调整
+- process template 格式可能被修订
+- 文档和部署指引会随着真实试用反馈继续完善
+
+请把 `v0.1.0` 视为用于评估、反馈和迭代的早期公开基线。
+
+### 后续方向
+
+`v0.1.0` 之后的近期重点包括：
+
+- 用截图、demo 数据和更清晰的 setup 指引改善首次上手体验
+- 收紧兼容性和部署边界说明
+- 继续优化项目与 Agent 的使用体验
+- 扩展更适合贡献者参与的入口，例如文档和 i18n
+- 持续沉淀权限和工作流边界相关的设计决策

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -127,8 +127,8 @@ Near-term work after `v0.1.0` focuses on:
 
 - improving first-run onboarding with screenshots, demo data, and clearer setup
   guidance
-- tightening compatibility and deployment expectations
 - refining project and agent usability
+- tightening compatibility and deployment expectations
 - expanding contributor-friendly entry points such as documentation and i18n
 - continuing to document design decisions around permissions and workflow
   boundaries
@@ -240,7 +240,7 @@ HALF 仍处于 `v0.x` 阶段。在 `v0.x` 期间：
 `v0.1.0` 之后的近期重点包括：
 
 - 用截图、demo 数据和更清晰的 setup 指引改善首次上手体验
-- 收紧兼容性和部署边界说明
 - 继续优化项目与 Agent 的使用体验
+- 收紧兼容性和部署边界说明
 - 扩展更适合贡献者参与的入口，例如文档和 i18n
 - 持续沉淀权限和工作流边界相关的设计决策

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,87 @@
+# HALF v0.1.0 Release Notes
+
+Release date: 2026-04-24
+
+## Summary
+
+`v0.1.0` is the first formal public release of HALF.
+
+This release establishes the core product boundary:
+
+- HALF is a human-in-the-loop multi-agent coordination console
+- it does not directly run external agents on behalf of the user
+- it focuses on prompt generation, Git-based result tracking, task orchestration,
+  and operator-facing workflow visibility
+
+## Included In v0.1.0
+
+Core capabilities available in this release:
+
+- project creation and project-scoped agent coordination
+- plan generation via prompt flow or process templates
+- DAG-based task execution workflow
+- Git-backed result detection using fixed task directories and `result.json`
+- execution summary pages
+- agent availability tracking with subscription expiry and reset windows
+- process template management
+- owner-scoped project and task isolation
+- admin/user role separation
+- Docker Compose deployment path
+- public documentation for architecture, task lifecycle, project structure, and
+  UI principles
+
+## Not Included In v0.1.0
+
+The following are intentionally out of scope for this release:
+
+- fully automated agent execution
+- hardened multi-tenant hosting
+- broad compatibility guarantees across all deployment styles
+- mature long-term API stability
+- polished onboarding assets such as screenshots, demo seed data, and short
+  guided demos
+
+## Stability Notes
+
+HALF remains a `v0.x` project.
+
+That means:
+
+- some interfaces may still change
+- parts of the data model may still evolve
+- operational details may still be refined as real users trial the system
+
+Users should treat `v0.1.0` as an early open-source release suitable for
+controlled self-hosted evaluation and feedback, rather than as a finalized
+platform release.
+
+## Recommended Usage Boundary
+
+This release is best suited for:
+
+- self-hosted, single-tenant environments
+- teams or operators coordinating multiple coding agents manually
+- users who want Git-visible task outputs and explicit workflow state
+
+This release is not recommended as:
+
+- a generic Jira/Linear replacement
+- a drop-in SaaS product for untrusted users
+- an agent runner that directly automates all execution
+
+## Upgrade / Adoption Notes
+
+If you are trying HALF for the first time:
+
+- start with the Docker Compose deployment path in `README.md`
+- review `SECURITY.md` before exposing the service beyond localhost
+- treat the current release as a controlled trial rather than a production-hardened platform
+
+## What Comes Next
+
+The next iterations will prioritize:
+
+- better onboarding and trialability
+- clearer compatibility expectations
+- stronger release discipline and maintenance signals
+- continued refinement of the human-in-the-loop workflow


### PR DESCRIPTION
## Summary
- add bilingual release notes for `v0.1.0`
- document supported scope, unsupported scope, recommended usage boundary, known gaps, and near-term direction
- keep release notes in a single English + Simplified Chinese file for direct GitHub Release reuse

This PR supersedes the older commit reference in keting/half#28: the original draft commit `d3850db` has been replaced by the current `docs/release-v0.1.0` branch tip. The PR diff intentionally contains only `docs/releases/v0.1.0.md`.

## Release Timing
- This PR only adds the release notes; it does not create the `v0.1.0` tag or GitHub Release.
- The tag should be created later on the merged `main` commit, not on this branch.
- `Release date: TBD` should be replaced with the actual release date before publishing the GitHub Release notes.
- keting/half#27 remains the quality-gate decision point: maintainers can either wait for the clean Quick Start run before tagging, or accept `v0.1.0` as an early baseline with the known gap documented.

## Related Issues
- Tracks keting/half#28
- Known gaps now map to follow-up issues, including English i18n tracking in keting/lab-internal#3

## Verification
- Confirmed branch diff against `origin/main` only adds `docs/releases/v0.1.0.md`.