### PR TITLE
Fix demo agent settings catalog

### DIFF
--- a/src/backend/routers/tasks.py
+++ b/src/backend/routers/tasks.py
@@ -188,6 +188,13 @@ def _compute_predecessor_status(db: Session, task: Task, refresh: bool) -> Prede
             if p.status == "abandoned":
                 continue
             if p.status != "completed":
+                missing.append(
+                    MissingPredecessor(
+                        task_code=p.task_code,
+                        task_name=p.task_name,
+                        expected_path=p.result_file_path or p.expected_output_path or "",
+                    )
+                )
                 continue
             try:
                 path = p.result_file_path or normalize_expected_output_path(

--- a/src/backend/services/demo_seed.py
+++ b/src/backend/services/demo_seed.py
@@ -98,6 +98,8 @@ DEMO_AGENT_TYPE_CATALOG = [
     },
 ]
 
+LEGACY_DEFAULT_AGENT_TYPES = {"claude", "codex", "cursor", "windsurf"}
+
 DEMO_AGENT_ROLES = {
     "agent-1": "承担代码开发、本地部署自测、修改报告编写、测试与审查意见评估迭代、文档同步及最终代码和报告推送，适合具备开发、测试协调与工程交付能力的 Agent",
     "agent-2": "依据修改报告对测试环境系统进行在线功能与回归测试，验证问题修复效果，输出测试结论，无需访问源代码，适合专业系统测试与业务验证类 Agent",
@@ -262,6 +264,34 @@ def _ensure_agent_type_catalog(db: Session) -> None:
                 ))
 
 
+def _prune_unused_legacy_default_agent_types(db: Session) -> None:
+    """Keep the demo settings catalog focused without deleting user data.
+
+    The app seeds a generic catalog before the demo project is loaded. In demo
+    databases that leaves unused defaults such as cursor/windsurf alongside the
+    three demo agent types. Prune only known legacy defaults, and only when no
+    Agent references them.
+    """
+    used_type_names = {
+        row[0]
+        for row in db.query(Agent.agent_type).filter(Agent.agent_type.isnot(None)).distinct().all()
+    }
+    removable_names = LEGACY_DEFAULT_AGENT_TYPES - used_type_names
+    if not removable_names:
+        return
+
+    removable_types = db.query(AgentTypeConfig).filter(AgentTypeConfig.name.in_(removable_names)).all()
+    removable_type_ids = [agent_type.id for agent_type in removable_types]
+    if not removable_type_ids:
+        return
+
+    db.query(AgentTypeModelMap).filter(
+        AgentTypeModelMap.agent_type_id.in_(removable_type_ids)
+    ).delete(synchronize_session=False)
+    for agent_type in removable_types:
+        db.delete(agent_type)
+
+
 def _template_json() -> dict:
     return {
         "plan_name": "中等改动功能开发与 Bug 修复全流程执行模版",
@@ -365,6 +395,7 @@ def seed_demo_project(db: Session, admin: User) -> bool:
         for spec in DEMO_AGENTS
     }
     _ensure_agent_type_catalog(db)
+    _prune_unused_legacy_default_agent_types(db)
     template = _ensure_template(db, admin)
     db.flush()
 

--- a/src/backend/services/demo_seed.py
+++ b/src/backend/services/demo_seed.py
@@ -4,7 +4,20 @@ from datetime import timedelta
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from models import Agent, GlobalSetting, ProcessTemplate, Project, ProjectPlan, Task, TaskEvent, User, utcnow
+from models import (
+    Agent,
+    AgentTypeConfig,
+    AgentTypeModelMap,
+    GlobalSetting,
+    ModelDefinition,
+    ProcessTemplate,
+    Project,
+    ProjectPlan,
+    Task,
+    TaskEvent,
+    User,
+    utcnow,
+)
 from services.project_agents import serialize_agent_assignments
 
 DEMO_META_KEY = "demo_project_seed_v1"
@@ -64,6 +77,24 @@ DEMO_AGENTS = [
         "models": ["Opus 4.6", "gpt-5.4", "Sonnet 4.6", "Opus 4.7"],
         "co_located": False,
         "display_order": 3,
+    },
+]
+
+DEMO_AGENT_TYPE_CATALOG = [
+    {
+        "name": "claude-max",
+        "description": "Claude Max subscription agent for deep review, architecture, and complex reasoning tasks.",
+        "models": ["Opus 4.7", "Sonnet 4.6"],
+    },
+    {
+        "name": "chatgpt-pro",
+        "description": "ChatGPT Pro agent for high-complexity implementation, planning, and end-to-end delivery.",
+        "models": ["gpt-5.5", "gpt-5.4"],
+    },
+    {
+        "name": "copilot-pro",
+        "description": "Copilot Pro agent for implementation support, testing, and code review workflows.",
+        "models": ["Opus 4.6", "gpt-5.4", "Sonnet 4.6", "Opus 4.7"],
     },
 ]
 
@@ -186,6 +217,51 @@ def _ensure_agent(db: Session, admin: User, spec: dict) -> Agent:
     return agent
 
 
+def _ensure_agent_type_catalog(db: Session) -> None:
+    max_order = db.query(AgentTypeConfig.display_order).order_by(
+        AgentTypeConfig.display_order.desc(),
+        AgentTypeConfig.id.desc(),
+    ).first()
+    next_type_order = (max_order[0] + 1) if max_order and max_order[0] is not None else 0
+
+    for type_spec in DEMO_AGENT_TYPE_CATALOG:
+        agent_type = db.query(AgentTypeConfig).filter(AgentTypeConfig.name == type_spec["name"]).first()
+        if agent_type is None:
+            agent_type = AgentTypeConfig(
+                name=type_spec["name"],
+                description=type_spec["description"],
+                display_order=next_type_order,
+            )
+            next_type_order += 1
+            db.add(agent_type)
+            db.flush()
+        elif not agent_type.description:
+            agent_type.description = type_spec["description"]
+
+        for model_order, model_name in enumerate(type_spec["models"]):
+            model_def = db.query(ModelDefinition).filter(ModelDefinition.name == model_name).first()
+            if model_def is None:
+                model_def = ModelDefinition(
+                    name=model_name,
+                    capability=_MODEL_CAPABILITIES.get(model_name),
+                )
+                db.add(model_def)
+                db.flush()
+            elif not model_def.capability:
+                model_def.capability = _MODEL_CAPABILITIES.get(model_name)
+
+            existing_map = db.query(AgentTypeModelMap).filter(
+                AgentTypeModelMap.agent_type_id == agent_type.id,
+                AgentTypeModelMap.model_definition_id == model_def.id,
+            ).first()
+            if existing_map is None:
+                db.add(AgentTypeModelMap(
+                    agent_type_id=agent_type.id,
+                    model_definition_id=model_def.id,
+                    display_order=model_order,
+                ))
+
+
 def _template_json() -> dict:
     return {
         "plan_name": "中等改动功能开发与 Bug 修复全流程执行模版",
@@ -288,6 +364,7 @@ def seed_demo_project(db: Session, admin: User) -> bool:
         spec["slug"]: _ensure_agent(db, admin, spec)
         for spec in DEMO_AGENTS
     }
+    _ensure_agent_type_catalog(db)
     template = _ensure_template(db, admin)
     db.flush()
 

--- a/src/backend/tests/test_demo_seed.py
+++ b/src/backend/tests/test_demo_seed.py
@@ -12,7 +12,7 @@ if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 
 from auth import hash_password
-from models import Agent, Base, ProcessTemplate, Project, ProjectPlan, Task, TaskEvent, User
+from models import Agent, AgentTypeConfig, AgentTypeModelMap, Base, ModelDefinition, ProcessTemplate, Project, ProjectPlan, Task, TaskEvent, User
 from services.demo_seed import DEMO_PROJECT_NAME, DEMO_TEMPLATE_NAME, seed_demo_project
 
 
@@ -74,6 +74,25 @@ class DemoSeedTests(unittest.TestCase):
         agents = {agent.slug: agent for agent in self.db.query(Agent).all()}
         self.assertEqual(set(agents), {"claude-max", "codex-pro", "copilot-pro"})
         self.assertEqual(agents["codex-pro"].model_name, "gpt-5.5")
+
+        agent_types = {
+            agent_type.name: agent_type
+            for agent_type in self.db.query(AgentTypeConfig)
+            .filter(AgentTypeConfig.name.in_(["claude-max", "chatgpt-pro", "copilot-pro"]))
+            .all()
+        }
+        self.assertEqual(set(agent_types), {"claude-max", "chatgpt-pro", "copilot-pro"})
+        models_by_id = {model.id: model.name for model in self.db.query(ModelDefinition).all()}
+
+        def type_models(type_name: str) -> list[str]:
+            maps = self.db.query(AgentTypeModelMap).filter(
+                AgentTypeModelMap.agent_type_id == agent_types[type_name].id,
+            ).order_by(AgentTypeModelMap.display_order, AgentTypeModelMap.id).all()
+            return [models_by_id[mapping.model_definition_id] for mapping in maps]
+
+        self.assertEqual(type_models("claude-max"), ["Opus 4.7", "Sonnet 4.6"])
+        self.assertEqual(type_models("chatgpt-pro"), ["gpt-5.5", "gpt-5.4"])
+        self.assertEqual(type_models("copilot-pro"), ["Opus 4.6", "gpt-5.4", "Sonnet 4.6", "Opus 4.7"])
 
     def test_seed_is_idempotent(self):
         self.assertTrue(seed_demo_project(self.db, self.admin))

--- a/src/backend/tests/test_demo_seed.py
+++ b/src/backend/tests/test_demo_seed.py
@@ -94,6 +94,44 @@ class DemoSeedTests(unittest.TestCase):
         self.assertEqual(type_models("chatgpt-pro"), ["gpt-5.5", "gpt-5.4"])
         self.assertEqual(type_models("copilot-pro"), ["Opus 4.6", "gpt-5.4", "Sonnet 4.6", "Opus 4.7"])
 
+    def test_seed_prunes_unused_legacy_default_agent_types_from_demo_catalog(self):
+        self.db.add_all([
+            AgentTypeConfig(name="claude"),
+            AgentTypeConfig(name="codex"),
+            AgentTypeConfig(name="cursor"),
+            AgentTypeConfig(name="windsurf"),
+            AgentTypeConfig(name="custom-reviewer"),
+        ])
+        self.db.commit()
+
+        seed_demo_project(self.db, self.admin)
+
+        type_names = {agent_type.name for agent_type in self.db.query(AgentTypeConfig).all()}
+        self.assertNotIn("claude", type_names)
+        self.assertNotIn("codex", type_names)
+        self.assertNotIn("cursor", type_names)
+        self.assertNotIn("windsurf", type_names)
+        self.assertIn("custom-reviewer", type_names)
+        self.assertIn("claude-max", type_names)
+        self.assertIn("chatgpt-pro", type_names)
+        self.assertIn("copilot-pro", type_names)
+
+    def test_seed_keeps_legacy_default_agent_type_if_existing_agent_uses_it(self):
+        self.db.add(AgentTypeConfig(name="claude"))
+        self.db.add(Agent(
+            name="Existing Claude",
+            slug="existing-claude",
+            agent_type="claude",
+            created_by=self.admin.id,
+        ))
+        self.db.commit()
+
+        seed_demo_project(self.db, self.admin)
+
+        type_names = {agent_type.name for agent_type in self.db.query(AgentTypeConfig).all()}
+        self.assertIn("claude", type_names)
+        self.assertIn("claude-max", type_names)
+
     def test_seed_is_idempotent(self):
         self.assertTrue(seed_demo_project(self.db, self.admin))
         self.assertFalse(seed_demo_project(self.db, self.admin))

--- a/src/backend/tests/test_task_predecessor_status.py
+++ b/src/backend/tests/test_task_predecessor_status.py
@@ -76,12 +76,13 @@ class TaskPredecessorStatusTests(unittest.TestCase):
         self.assertTrue(result.ready)
         self.assertEqual(result.missing, [])
 
-    def test_predecessor_status_ignores_non_completed_predecessor_output(self):
+    def test_predecessor_status_blocks_on_non_completed_predecessor(self):
         task = self._seed_task_chain("running")
-        with patch("routers.tasks.git_service.file_exists", return_value=False):
+        with patch("routers.tasks.git_service.file_exists") as mock_file_exists:
             result = _compute_predecessor_status(self.db, task, refresh=False)
-        self.assertTrue(result.ready)
-        self.assertEqual(result.missing, [])
+        mock_file_exists.assert_not_called()
+        self.assertFalse(result.ready)
+        self.assertEqual([item.task_code for item in result.missing], ["TASK-001"])
 
     def test_project_predecessor_status_marks_dependency_chain_ready_and_blocked(self):
         project = Project(

--- a/src/frontend/src/pages/ProjectDetailPage.test.ts
+++ b/src/frontend/src/pages/ProjectDetailPage.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { formatBlockedPredecessor } from './ProjectDetailPage';
+
+describe('formatBlockedPredecessor', () => {
+  it('describes blocked tasks as waiting for predecessors to complete', () => {
+    expect(formatBlockedPredecessor({
+      task_code: 'T2_TEST',
+      task_name: '测试环境在线验证',
+      expected_path: 'demo/outputs/T2_TEST/result.json',
+    })).toBe('等待 T2_TEST（测试环境在线验证）完成');
+  });
+
+  it('falls back to task code for unknown predecessors', () => {
+    expect(formatBlockedPredecessor({
+      task_code: 'T9_UNKNOWN',
+      task_name: '(未知)',
+      expected_path: '',
+    })).toBe('等待 T9_UNKNOWN 完成');
+  });
+});

--- a/src/frontend/src/pages/ProjectDetailPage.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage.tsx
@@ -23,6 +23,13 @@ interface TaskWithReadiness extends Task {
   readiness?: PredecessorStatus;
 }
 
+export function formatBlockedPredecessor(item: PredecessorStatus['missing'][number]) {
+  if (item.task_name && item.task_name !== '(未知)') {
+    return `等待 ${item.task_code}（${item.task_name}）完成`;
+  }
+  return `等待 ${item.task_code} 完成`;
+}
+
 function getTaskTiming(task: Task) {
   if (task.status === 'completed' && task.completed_at) {
     return `完成于 ${formatDateTime(task.completed_at)}`;
@@ -266,14 +273,14 @@ export default function ProjectDetailPage() {
                   <div className="task-queue-warning-list">
                     {task.readiness?.missing.map((item) => (
                       <div key={`${task.id}-${item.task_code}`} className="task-queue-warning-item">
-                        缺少 {item.task_code} 输出
+                        {formatBlockedPredecessor(item)}
                       </div>
                     ))}
                   </div>
                 </div>
               ))
             ) : (
-              <div className="project-console-empty">没有发现缺失上游产物的阻塞项。</div>
+              <div className="project-console-empty">当前没有被前置任务阻塞的待处理任务。</div>
             )}
           </div>
 


### PR DESCRIPTION
## Summary

- Seed demo agent settings catalog entries for claude-max, chatgpt-pro, and copilot-pro
- Prune unused legacy default agent types from fresh demo databases
- Clarify blocked task queue wording in the project detail page
- Align single-task predecessor readiness with project-level readiness

## Verification

- Backend: python3 -m pytest tests/ -q
- Frontend: npm test -- --run
- Frontend build: npm run build
- Fresh Docker deployment reviewed externally with clean volumes
