### PR TITLE
docs: add Zenodo DOI citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
     # email: "you@example.com"
 repository-code: "https://github.com/keting/half"
 license: Apache-2.0
-doi: 10.5281/zenodo.19809714
+doi: 10.5281/zenodo.19809712
 version: "0.2.1"
 date-released: "2026-04-27"
 keywords:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,6 +11,7 @@ authors:
     # email: "you@example.com"
 repository-code: "https://github.com/keting/half"
 license: Apache-2.0
+doi: 10.5281/zenodo.19809714
 version: "0.2.1"
 date-released: "2026-04-27"
 keywords:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [English](./README.md) | [简体中文](./README.zh-CN.md)
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19809714.svg)](https://doi.org/10.5281/zenodo.19809714)
+[![DOI](https://zenodo.org/badge/1196783873.svg)](https://doi.org/10.5281/zenodo.19809712)
 [![CI](https://github.com/keting/half/actions/workflows/ci.yml/badge.svg)](https://github.com/keting/half/actions/workflows/ci.yml)
 
 # HALF - Human-AI Loop Framework
@@ -271,10 +271,10 @@ See [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 ## Citation
 
 If you use HALF in your research, teaching, or software engineering
-experiments, please cite the archived Zenodo release:
+experiments, please cite the archived Zenodo project record:
 
 Keting. (2026). HALF: Human-AI Loop Framework (v0.2.1). Zenodo.
-https://doi.org/10.5281/zenodo.19809714
+https://doi.org/10.5281/zenodo.19809712
 
 The citation metadata is also available in [`CITATION.cff`](./CITATION.cff).
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,11 @@ https://doi.org/10.5281/zenodo.19809712
 
 The citation metadata is also available in [`CITATION.cff`](./CITATION.cff).
 
+DOI maintenance note: HALF uses the Zenodo Concept DOI for repository-level
+citation and metadata. Version-specific DOIs are managed by Zenodo and are not
+written back into the repository for every release. For exact reproducibility,
+use the version-specific DOI shown on the corresponding Zenodo record.
+
 ## Screenshots
 
 Screenshots will be added in v0.2.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [English](./README.md) | [简体中文](./README.zh-CN.md)
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19809714.svg)](https://doi.org/10.5281/zenodo.19809714)
 [![CI](https://github.com/keting/half/actions/workflows/ci.yml/badge.svg)](https://github.com/keting/half/actions/workflows/ci.yml)
 
 # HALF - Human-AI Loop Framework
@@ -266,6 +267,16 @@ to report vulnerabilities.
 ## Contributing
 
 See [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+## Citation
+
+If you use HALF in your research, teaching, or software engineering
+experiments, please cite the archived Zenodo release:
+
+Keting. (2026). HALF: Human-AI Loop Framework (v0.2.1). Zenodo.
+https://doi.org/10.5281/zenodo.19809714
+
+The citation metadata is also available in [`CITATION.cff`](./CITATION.cff).
 
 ## Screenshots
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -254,6 +254,10 @@ https://doi.org/10.5281/zenodo.19809712
 
 引用元数据也可以在 [`CITATION.cff`](./CITATION.cff) 中查看。
 
+DOI 维护说明：HALF 使用 Zenodo Concept DOI 作为仓库级引用和元数据 DOI。
+版本级 DOI 由 Zenodo 管理，不会在每个 release 后都回写到仓库。若需要精确
+复现某个版本，请使用对应 Zenodo 记录中显示的版本级 DOI。
+
 ## 截图
 
 截图将在 v0.2 版本补充。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,6 @@
 [English](./README.md) | [简体中文](./README.zh-CN.md)
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19809714.svg)](https://doi.org/10.5281/zenodo.19809714)
 [![CI](https://github.com/keting/half/actions/workflows/ci.yml/badge.svg)](https://github.com/keting/half/actions/workflows/ci.yml)
 
 # HALF - Human-AI Loop Framework
@@ -243,6 +244,15 @@ HALF 通常以自托管方式部署。用于生产环境时，请保持
 ## 贡献
 
 贡献说明请参阅 [`CONTRIBUTING.md`](./CONTRIBUTING.md)。
+
+## 引用
+
+如果你在研究、教学或软件工程实验中使用 HALF，请引用 Zenodo 归档版本：
+
+Keting. (2026). HALF: Human-AI Loop Framework (v0.2.1). Zenodo.
+https://doi.org/10.5281/zenodo.19809714
+
+引用元数据也可以在 [`CITATION.cff`](./CITATION.cff) 中查看。
 
 ## 截图
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 [English](./README.md) | [简体中文](./README.zh-CN.md)
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19809714.svg)](https://doi.org/10.5281/zenodo.19809714)
+[![DOI](https://zenodo.org/badge/1196783873.svg)](https://doi.org/10.5281/zenodo.19809712)
 [![CI](https://github.com/keting/half/actions/workflows/ci.yml/badge.svg)](https://github.com/keting/half/actions/workflows/ci.yml)
 
 # HALF - Human-AI Loop Framework
@@ -247,10 +247,10 @@ HALF 通常以自托管方式部署。用于生产环境时，请保持
 
 ## 引用
 
-如果你在研究、教学或软件工程实验中使用 HALF，请引用 Zenodo 归档版本：
+如果你在研究、教学或软件工程实验中使用 HALF，请引用 Zenodo 项目归档记录：
 
 Keting. (2026). HALF: Human-AI Loop Framework (v0.2.1). Zenodo.
-https://doi.org/10.5281/zenodo.19809714
+https://doi.org/10.5281/zenodo.19809712
 
 引用元数据也可以在 [`CITATION.cff`](./CITATION.cff) 中查看。
 

--- a/docs/releases/v0.2.1.md
+++ b/docs/releases/v0.2.1.md
@@ -15,7 +15,9 @@ coordination.
 
 - Updated `CITATION.cff` to version `0.2.1` for Zenodo DOI registration.
 - Updated current documentation version markers to `v0.2.1`.
-- Added the Zenodo archive DOI:
+- Added the Zenodo project Concept DOI:
+  https://doi.org/10.5281/zenodo.19809712
+- Added the Zenodo v0.2.1 version archive DOI:
   https://doi.org/10.5281/zenodo.19809714
 
 ### Notes
@@ -23,7 +25,9 @@ coordination.
 - No major functional changes.
 - No database migration.
 - No deployment behavior changes.
-- Zenodo archive:
+- Zenodo Concept DOI:
+  https://doi.org/10.5281/zenodo.19809712
+- Zenodo version archive:
   https://doi.org/10.5281/zenodo.19809714
 
 ## 简体中文
@@ -37,7 +41,9 @@ human-in-the-loop 的多 agent coding workflow 协调。
 
 - 将 `CITATION.cff` 更新到版本 `0.2.1`，用于 Zenodo DOI 注册。
 - 将当前文档的版本标记更新为 `v0.2.1`。
-- 补充 Zenodo 归档 DOI：
+- 补充 Zenodo 项目 Concept DOI：
+  https://doi.org/10.5281/zenodo.19809712
+- 补充 Zenodo v0.2.1 版本归档 DOI：
   https://doi.org/10.5281/zenodo.19809714
 
 ### 说明
@@ -45,5 +51,7 @@ human-in-the-loop 的多 agent coding workflow 协调。
 - 无主要功能变化。
 - 无数据库迁移。
 - 无部署行为变化。
-- Zenodo 归档：
+- Zenodo Concept DOI：
+  https://doi.org/10.5281/zenodo.19809712
+- Zenodo 版本归档：
   https://doi.org/10.5281/zenodo.19809714

--- a/docs/releases/v0.2.1.md
+++ b/docs/releases/v0.2.1.md
@@ -15,12 +15,16 @@ coordination.
 
 - Updated `CITATION.cff` to version `0.2.1` for Zenodo DOI registration.
 - Updated current documentation version markers to `v0.2.1`.
+- Added the Zenodo archive DOI:
+  https://doi.org/10.5281/zenodo.19809714
 
 ### Notes
 
 - No major functional changes.
 - No database migration.
 - No deployment behavior changes.
+- Zenodo archive:
+  https://doi.org/10.5281/zenodo.19809714
 
 ## 简体中文
 
@@ -33,9 +37,13 @@ human-in-the-loop 的多 agent coding workflow 协调。
 
 - 将 `CITATION.cff` 更新到版本 `0.2.1`，用于 Zenodo DOI 注册。
 - 将当前文档的版本标记更新为 `v0.2.1`。
+- 补充 Zenodo 归档 DOI：
+  https://doi.org/10.5281/zenodo.19809714
 
 ### 说明
 
 - 无主要功能变化。
 - 无数据库迁移。
 - 无部署行为变化。
+- Zenodo 归档：
+  https://doi.org/10.5281/zenodo.19809714

--- a/docs/releases/v0.2.1.md
+++ b/docs/releases/v0.2.1.md
@@ -17,18 +17,16 @@ coordination.
 - Updated current documentation version markers to `v0.2.1`.
 - Added the Zenodo project Concept DOI:
   https://doi.org/10.5281/zenodo.19809712
-- Added the Zenodo v0.2.1 version archive DOI:
-  https://doi.org/10.5281/zenodo.19809714
 
 ### Notes
 
 - No major functional changes.
 - No database migration.
 - No deployment behavior changes.
-- Zenodo Concept DOI:
+- This release is archived on Zenodo under the HALF project record:
   https://doi.org/10.5281/zenodo.19809712
-- Zenodo version archive:
-  https://doi.org/10.5281/zenodo.19809714
+- Version-specific DOIs are managed by Zenodo and are not written back into the
+  repository for every release.
 
 ## 简体中文
 
@@ -43,15 +41,12 @@ human-in-the-loop 的多 agent coding workflow 协调。
 - 将当前文档的版本标记更新为 `v0.2.1`。
 - 补充 Zenodo 项目 Concept DOI：
   https://doi.org/10.5281/zenodo.19809712
-- 补充 Zenodo v0.2.1 版本归档 DOI：
-  https://doi.org/10.5281/zenodo.19809714
 
 ### 说明
 
 - 无主要功能变化。
 - 无数据库迁移。
 - 无部署行为变化。
-- Zenodo Concept DOI：
+- 本版本已归档到 Zenodo 的 HALF 项目记录：
   https://doi.org/10.5281/zenodo.19809712
-- Zenodo 版本归档：
-  https://doi.org/10.5281/zenodo.19809714
+- 版本级 DOI 由 Zenodo 管理，不会在每个 release 后都回写到仓库。


### PR DESCRIPTION
## Summary

- Add the Zenodo DOI badge to README.md and README.zh-CN.md.
- Add bilingual citation sections with the v0.2.1 Zenodo DOI.
- Add the DOI field to CITATION.cff while preserving existing author/version/date metadata.
- Update v0.2.1 release notes with the Zenodo archive DOI.

## Checks

- Confirmed no .zenodo.json exists; did not add one.
- Searched for zenodo, DOI, 10.5281, citation, and v0.2.1 references.
- Parsed CITATION.cff with PyYAML and verified doi/version/date-released.

No business code, package-lock.json, or historical release facts were changed.
