### PR TITLE
docs: remove version from concept DOI citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ See [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 If you use HALF in your research, teaching, or software engineering
 experiments, please cite the archived Zenodo project record:
 
-Keting. (2026). HALF: Human-AI Loop Framework (v0.2.1). Zenodo.
+Keting. (2026). HALF: Human-AI Loop Framework. Zenodo.
 https://doi.org/10.5281/zenodo.19809712
 
 The citation metadata is also available in [`CITATION.cff`](./CITATION.cff).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -248,7 +248,7 @@ HALF 通常以自托管方式部署。用于生产环境时，请保持
 
 如果你在研究、教学或软件工程实验中使用 HALF，请引用 Zenodo 项目归档记录：
 
-Keting. (2026). HALF: Human-AI Loop Framework (v0.2.1). Zenodo.
+Keting. (2026). HALF: Human-AI Loop Framework. Zenodo.
 https://doi.org/10.5281/zenodo.19809712
 
 引用元数据也可以在 [`CITATION.cff`](./CITATION.cff) 中查看。


### PR DESCRIPTION
## Summary

- Remove the hard-coded `(v0.2.1)` version from README.md and README.zh-CN.md concept DOI citation text.
- Keep the README DOI badge and citation URL on the Zenodo Concept DOI: https://doi.org/10.5281/zenodo.19809712.
- Keep CITATION.cff using the Concept DOI and leave release/version metadata unchanged.

## Checks

- Searched for `HALF: Human-AI Loop Framework (v0.2.1)`; no matches remain.
- Searched for `10.5281/zenodo.19809714`; no matches remain.
- Confirmed README badge and CITATION.cff use `10.5281/zenodo.19809712`.

No business code, package files, .zenodo.json, or historical release facts were changed.
