### PR TITLE
fix: skip CodeQL gate on fork PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,6 +50,10 @@ jobs:
           ACTIONS_CHANGED: ${{ needs.changes.outputs.actions }}
         with:
           script: |
+            const pullRequest = context.payload.pull_request;
+            const isForkPullRequest = Boolean(
+              pullRequest && pullRequest.head.repo.full_name !== pullRequest.base.repo.full_name,
+            );
             const requiredChecks = [];
 
             if (process.env.JS_CHANGED === 'true') {
@@ -64,6 +68,13 @@ jobs:
 
             if (requiredChecks.length === 0) {
               core.info('No code or workflow changes detected; CodeQL gate passes without waiting for analysis checks.');
+              return;
+            }
+
+            if (isForkPullRequest) {
+              core.info(
+                `Skipping CodeQL gate for fork pull request ${pullRequest.number}; GitHub-managed CodeQL analyze checks are not emitted for this context.`,
+              );
               return;
             }
 


### PR DESCRIPTION
## Summary
- skip the CodeQL gate wait loop for fork pull requests
- keep the existing wait behavior for same-repository PRs and main pushes
- avoid deadlocking required checks when GitHub-managed CodeQL analyze checks are not emitted for forks

## Testing
- parsed .github/workflows/codeql.yml successfully with Python YAML loader