### PR TITLE
fix: checkout before CodeQL path filtering

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,9 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       actions: ${{ steps.filter.outputs.actions }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@v3


### PR DESCRIPTION
## Summary

Fix the CodeQL Gate workflow failing in the `Detect CodeQL Targets` job on push events.

`dorny/paths-filter@v3` calls git commands when evaluating changed paths. The job did not check out the repository first, so the runner had no `.git` directory and failed with:

`fatal: not a git repository (or any of the parent directories): .git`

This PR adds `actions/checkout@v4` before `dorny/paths-filter@v3` in `.github/workflows/codeql.yml`.

## Validation

- [x] `git diff --check`
- [x] Confirmed the change is limited to `.github/workflows/codeql.yml`
- [x] Compared against the failing job log: https://github.com/keting/half/actions/runs/25366041552/job/74377018311
