### PR TITLE
add tooltip instructions

### DIFF
--- a/src/frontend/src/components/CoLocatedFieldLabel.tsx
+++ b/src/frontend/src/components/CoLocatedFieldLabel.tsx
@@ -1,0 +1,16 @@
+import HelpTooltip from './HelpTooltip';
+
+const CO_LOCATED_HELP_TEXT = '勾选则表示该agent所在的机器与项目部署的机器是同一台';
+
+interface CoLocatedFieldLabelProps {
+  label?: string;
+}
+
+export default function CoLocatedFieldLabel({ label = '同服务器' }: CoLocatedFieldLabelProps) {
+  return (
+    <span className="checkbox-field-label">
+      <span>{label}</span>
+      <HelpTooltip text={CO_LOCATED_HELP_TEXT} ariaLabel={`${label}说明`} />
+    </span>
+  );
+}

--- a/src/frontend/src/components/HelpTooltip.tsx
+++ b/src/frontend/src/components/HelpTooltip.tsx
@@ -1,0 +1,17 @@
+interface HelpTooltipProps {
+  text: string;
+  ariaLabel?: string;
+}
+
+export default function HelpTooltip({ text, ariaLabel = '查看说明' }: HelpTooltipProps) {
+  return (
+    <span className="help-tooltip">
+      <span className="help-tooltip-trigger" tabIndex={0} role="img" aria-label={ariaLabel}>
+        ?
+      </span>
+      <span className="help-tooltip-bubble" role="tooltip">
+        {text}
+      </span>
+    </span>
+  );
+}

--- a/src/frontend/src/components/HelpTooltip.tsx
+++ b/src/frontend/src/components/HelpTooltip.tsx
@@ -1,15 +1,31 @@
+import { useId } from 'react';
+
 interface HelpTooltipProps {
   text: string;
   ariaLabel?: string;
 }
 
 export default function HelpTooltip({ text, ariaLabel = '查看说明' }: HelpTooltipProps) {
+  const tooltipId = useId();
+
+  const stopLabelActivation = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
   return (
     <span className="help-tooltip">
-      <span className="help-tooltip-trigger" tabIndex={0} role="img" aria-label={ariaLabel}>
+      <button
+        type="button"
+        className="help-tooltip-trigger"
+        aria-label={ariaLabel}
+        aria-describedby={tooltipId}
+        onMouseDown={stopLabelActivation}
+        onClick={stopLabelActivation}
+      >
         ?
-      </span>
-      <span className="help-tooltip-bubble" role="tooltip">
+      </button>
+      <span className="help-tooltip-bubble" id={tooltipId} role="tooltip">
         {text}
       </span>
     </span>

--- a/src/frontend/src/pages/AgentsPage.tsx
+++ b/src/frontend/src/pages/AgentsPage.tsx
@@ -7,6 +7,7 @@ import PageHeader from '../components/PageHeader';
 import SectionCard from '../components/SectionCard';
 // StatusBadge is rendered inline in agent cards for the dropdown interaction
 import ModelBadge from '../components/ModelBadge';
+import CoLocatedFieldLabel from '../components/CoLocatedFieldLabel';
 import { deriveAgentStatus, isSubscriptionExpiringSoon, getAgentModels } from '../utils/agents';
 
 interface AgentModelForm {
@@ -555,13 +556,13 @@ export default function AgentsPage() {
                   <input type="datetime-local" value={form.subscription_expires_at} onChange={(e) => updateField('subscription_expires_at', e.target.value)} />
                 </div>
               </div>
-              <label className="checkbox-field" title="勾选则表示该agent所在的机器与项目部署的机器是同一台">
+              <label className="checkbox-field">
                 <input
                   type="checkbox"
                   checked={form.co_located}
                   onChange={(e) => updateField('co_located', e.target.checked)}
                 />
-                <span>同服务器</span>
+                <CoLocatedFieldLabel />
               </label>
               <label className="checkbox-field" title="取消勾选会停用该 Agent；引用它的项目必须先移除该引用，才能继续编辑或生成新计划">
                 <input

--- a/src/frontend/src/pages/ProjectNewPage.tsx
+++ b/src/frontend/src/pages/ProjectNewPage.tsx
@@ -6,6 +6,7 @@ import PageHeader from '../components/PageHeader';
 import SectionCard from '../components/SectionCard';
 import StatusBadge from '../components/StatusBadge';
 import ModelBadge from '../components/ModelBadge';
+import CoLocatedFieldLabel from '../components/CoLocatedFieldLabel';
 import { deriveAgentStatus, getAgentModels, summarizeAgentCapabilities } from '../utils/agents';
 import { validateGitRepoUrl } from '../utils/gitRepoUrl';
 
@@ -386,7 +387,6 @@ export default function ProjectNewPage() {
                     {selected && (
                       <label
                         className="agent-select-card-colocation"
-                        title="勾选则表示该agent所在的机器与项目部署的机器是同一台"
                         onClick={(event) => event.stopPropagation()}
                       >
                         <input
@@ -394,7 +394,7 @@ export default function ProjectNewPage() {
                           checked={Boolean(agentCoLocated[agent.id])}
                           onChange={(event) => updateAgentCoLocated(agent.id, event.target.checked)}
                         />
-                        <span>同服务器</span>
+                        <CoLocatedFieldLabel />
                       </label>
                     )}
                   </div>

--- a/src/frontend/src/styles/index.css
+++ b/src/frontend/src/styles/index.css
@@ -402,6 +402,7 @@ body {
   position: relative;
   display: inline-flex;
   align-items: center;
+  flex: 0 0 auto;
 }
 
 .help-tooltip-trigger {
@@ -419,6 +420,7 @@ body {
   line-height: 1;
   cursor: help;
   user-select: none;
+  padding: 0;
 }
 
 .help-tooltip-trigger:focus-visible {
@@ -429,10 +431,11 @@ body {
 
 .help-tooltip-bubble {
   position: absolute;
-  left: calc(100% + 8px);
-  top: 50%;
+  left: 50%;
+  top: calc(100% + 8px);
   z-index: 20;
-  width: 240px;
+  width: max-content;
+  max-width: min(240px, calc(100vw - 32px));
   padding: 8px 10px;
   border-radius: 8px;
   background: #0f172a;
@@ -443,15 +446,17 @@ body {
   box-shadow: var(--shadow-md);
   opacity: 0;
   visibility: hidden;
-  transform: translateY(-50%);
+  transform: translateX(-50%) translateY(-4px);
   pointer-events: none;
-  transition: opacity 0.15s ease, visibility 0.15s ease;
+  overflow-wrap: anywhere;
+  transition: opacity 0.15s ease, visibility 0.15s ease, transform 0.15s ease;
 }
 
 .help-tooltip:hover .help-tooltip-bubble,
 .help-tooltip:focus-within .help-tooltip-bubble {
   opacity: 1;
   visibility: visible;
+  transform: translateX(-50%) translateY(0);
 }
 
 .form-actions {

--- a/src/frontend/src/styles/index.css
+++ b/src/frontend/src/styles/index.css
@@ -392,6 +392,68 @@ body {
   width: auto;
 }
 
+.checkbox-field-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.help-tooltip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.help-tooltip-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border: 1px solid #94a3b8;
+  border-radius: 999px;
+  background: #fff;
+  color: #475569;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: help;
+  user-select: none;
+}
+
+.help-tooltip-trigger:focus-visible {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.16);
+}
+
+.help-tooltip-bubble {
+  position: absolute;
+  left: calc(100% + 8px);
+  top: 50%;
+  z-index: 20;
+  width: 240px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: #0f172a;
+  color: #f8fafc;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+  box-shadow: var(--shadow-md);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-50%);
+  pointer-events: none;
+  transition: opacity 0.15s ease, visibility 0.15s ease;
+}
+
+.help-tooltip:hover .help-tooltip-bubble,
+.help-tooltip:focus-within .help-tooltip-bubble {
+  opacity: 1;
+  visibility: visible;
+}
+
 .form-actions {
   display: flex;
   gap: 12px;


### PR DESCRIPTION
## Summary

新增了前端可复用的悬浮提示组件（Tooltip），优化了“同服务器”相关表单项的交互体验。

**具体修改：**
1. 新增 `HelpTooltip` 基础组件（含 `index.css` 样式调整）。
2. 新增 `CoLocatedFieldLabel` 组合组件，将原有的纯文本复选框替换为“文案 + ? 提示图标”的形式。
3. 补充了清晰的提示文案：“勾选则表示该agent所在的机器与项目部署的机器是同一台”。
4. 在以下入口完成了无缝接入：
   - `ProjectNewPage.tsx` (创建/编辑项目页面)
   - `AgentsPage.tsx` (新增/编辑智能体页面)

Closes # 77

## Testing

- [ ] `cd src/backend && uv run python -m pytest tests/ -v`
- [ ] `cd src/frontend && npm test`
- [x] `cd src/frontend && npm run build` 
- [x] 本地热更新与 UI 走查：已在本地环境验证了 `ProjectNewPage` 和 `AgentsPage` 的渲染，确认 Tooltip 触发灵敏，文案无误，且不影响原有表单的逻辑。

## Checklist

- [x] The change stays scoped and focused.
- [x] Related issues are linked when applicable.
- [ ] Docs were updated where behavior, API shape, or setup changed.
- [x] No secrets, private URLs, or local machine paths were introduced.