### PR TITLE
docs: add v0.3.0 release notes

### DIFF
--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,126 @@
+# HALF v0.3.0 Release Notes
+
+Release date: 2026-05-08
+
+## English
+
+`v0.3.0` focuses on operational readiness for self-hosted HALF deployments. It
+adds an administrator-managed shared agent pool, mobile-friendly Feishu task
+notifications, stronger Git repository URL validation, Codex usage refresh
+cooldowns, and a substantially expanded user manual.
+
+This remains a `v0.x` self-hosted evaluation release. APIs and data models may
+continue to change between minor versions.
+
+### Highlights
+
+- Added administrator-created public agents that can be reused by all users.
+- Added Feishu notification support for task status updates, improving mobile
+  visibility into long-running workflows.
+- Added Codex usage refresh cooldown handling and automatic reset-time refresh.
+- Strengthened Git repository URL validation and related project creation /
+  settings error handling.
+- Fixed intermittent Plan-stage polling failures that could surface as backend
+  500 responses.
+- Fixed manual refresh behavior after Plan-stage polling timeouts.
+- Added bilingual end-user manuals with screenshots for the main HALF
+  workflows.
+- Added CodeQL coverage and tightened CI behavior for repository security
+  checks.
+- Migrated the backend dependency workflow to `uv`.
+
+### User-Facing Changes
+
+- Administrators can publish agents into a shared public pool, reducing
+  duplicate per-user agent setup for common team workflows.
+- Project setup gives clearer feedback for invalid or unsupported Git repository
+  URLs.
+- Task and planning workflows are more resilient when polling times out or
+  temporarily fails.
+- Feishu notifications can be configured so task updates are visible outside
+  the desktop browser.
+- Codex usage reset information is refreshed with cooldown protection to avoid
+  excessive update attempts.
+
+### Documentation
+
+- Added full English and Simplified Chinese user manuals:
+  - `docs/user-manual.md`
+  - `docs/user-manual.zh-CN.md`
+- Added user-manual screenshots for agents, projects, plans, tasks, templates,
+  settings, summary, and user management pages.
+- Added a minimal-loop README demo GIF.
+- Expanded contribution, security, roadmap, issue, discussion, and GitHub
+  collaboration guidance.
+
+### Engineering and Security
+
+- Added the repository CodeQL workflow.
+- Skips the CodeQL gate for fork pull requests where required permissions or
+  repository context may be unavailable.
+- Fixed CodeQL path-filter checkout ordering.
+- Added and expanded backend/frontend regression tests around public agents,
+  Git URL validation, Feishu notifications, Codex usage caching, project agent
+  availability, Plan polling, and manual refresh behavior.
+- Migrated backend packaging and lockfile management to `uv`.
+
+### Notes
+
+- This release includes backend behavior changes and new settings surfaces, so
+  self-hosted operators should review deployment configuration before upgrading.
+- No explicit manual database migration step is documented for this release.
+- The v0.3 GitHub milestone is complete at release preparation time.
+
+## 简体中文
+
+`v0.3.0` 重点提升 HALF 自托管部署的可运维性：加入管理员维护的公共 Agent
+池、移动端友好的飞书任务通知、更严格的 Git 仓库地址校验、Codex 用量刷新冷却
+机制，并大幅补充用户手册。
+
+本版本仍然是 `v0.x` 阶段的自托管评估版本。接口和数据模型仍可能在次版本间
+继续变化。
+
+### 重点变化
+
+- 支持管理员创建全用户可见的公共 Agent。
+- 支持飞书任务状态通知，便于在移动端跟踪长时间运行的工作流。
+- 支持 Codex 用量刷新冷却，并自动更新重置时间。
+- 强化 Git 仓库地址校验，并改进项目创建 / 设置页的错误提示。
+- 修复 Plan 阶段轮询偶发触发后端 500 的问题。
+- 修复 Plan 阶段轮询超时后手动刷新无效的问题。
+- 新增带截图的中英文用户手册，覆盖主要 HALF 工作流。
+- 增加 CodeQL 检查，并完善仓库安全相关 CI 行为。
+- 后端依赖管理迁移到 `uv`。
+
+### 面向用户的变化
+
+- 管理员可以将 Agent 发布到公共池，减少团队常用 Agent 的重复配置。
+- 项目配置中的 Git 仓库地址错误会得到更清晰的反馈。
+- 任务与规划流程在轮询超时或短暂失败时更稳定。
+- 可配置飞书通知，让任务状态更新不再依赖桌面浏览器页面。
+- Codex 用量重置时间会自动刷新，并通过冷却机制避免过于频繁的刷新请求。
+
+### 文档
+
+- 新增完整的英文和简体中文用户手册：
+  - `docs/user-manual.md`
+  - `docs/user-manual.zh-CN.md`
+- 补充 Agent、项目、规划、任务、模板、设置、摘要、用户管理等页面的手册截图。
+- 在 README 中补充最小闭环演示 GIF。
+- 扩展贡献指南、安全说明、路线图、issue / discussion 使用说明和 GitHub
+  协作流程文档。
+
+### 工程与安全
+
+- 新增仓库 CodeQL workflow。
+- 在 fork PR 场景下跳过 CodeQL gate，避免权限和仓库上下文不足导致误报。
+- 修复 CodeQL 路径过滤执行前未 checkout 的问题。
+- 补充和扩展公共 Agent、Git URL 校验、飞书通知、Codex 用量缓存、项目 Agent
+  可用性、Plan 轮询和手动刷新等回归测试。
+- 后端包管理和 lockfile 迁移到 `uv`。
+
+### 说明
+
+- 本版本包含后端行为变化和新的设置入口，自托管部署升级前建议检查部署配置。
+- 本版本没有记录需要手动执行的数据库迁移步骤。
+- 发布准备时，v0.3 GitHub milestone 已完成。


### PR DESCRIPTION
## Summary\n\n- Add bilingual release notes for HALF v0.3.0.\n- Capture the completed v0.3 milestone scope, including public agents, Feishu notifications, Codex usage refresh cooldowns, Git URL validation, Plan polling fixes, documentation updates, CodeQL, and uv migration.\n\n## Notes\n\n- The v0.3 milestone is complete: 0 open issues, 9 closed issues.\n- Create and push the v0.3.0 tag after this PR is merged into main.