### PR TITLE
fix: adjust sidebar display

### DIFF
--- a/src/frontend/src/styles/index.css
+++ b/src/frontend/src/styles/index.css
@@ -38,14 +38,22 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+html,
+body,
+#root {
+  height: 100%;
+}
+
 /* ===== Layout ===== */
 .app-layout {
   display: flex;
-  min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
 }
 
 .sidebar {
   width: 240px;
+  height: 100vh;
   background: var(--color-sidebar);
   color: var(--color-sidebar-text);
   display: flex;
@@ -124,6 +132,7 @@ body {
 
 .main-content {
   flex: 1;
+  height: 100vh;
   overflow-y: auto;
   min-width: 0;
 }

--- a/src/frontend/src/styles/index.css
+++ b/src/frontend/src/styles/index.css
@@ -53,7 +53,6 @@ body,
 
 .sidebar {
   width: 240px;
-  height: 100vh;
   background: var(--color-sidebar);
   color: var(--color-sidebar-text);
   display: flex;
@@ -132,7 +131,6 @@ body,
 
 .main-content {
   flex: 1;
-  height: 100vh;
   overflow-y: auto;
   min-width: 0;
 }
@@ -1229,26 +1227,71 @@ body,
   color: #7f1d1d;
   font-size: 13px;
 }
-.missing-pred-banner strong { display: block; margin-bottom: 4px; color: #b91c1c; }
-.missing-pred-banner ul { margin: 8px 0; padding-left: 18px; }
-.missing-pred-banner .missing-path { color: #991b1b; font-family: monospace; }
-.missing-pred-banner .btn-sm { font-size: 12px; padding: 4px 10px; }
+
+.missing-pred-banner strong {
+  display: block;
+  margin-bottom: 4px;
+  color: #b91c1c;
+}
+
+.missing-pred-banner ul {
+  margin: 8px 0;
+  padding-left: 18px;
+}
+
+.missing-pred-banner .missing-path {
+  color: #991b1b;
+  font-family: monospace;
+}
+
+.missing-pred-banner .btn-sm {
+  font-size: 12px;
+  padding: 4px 10px;
+}
 
 .modal-backdrop {
-  position: fixed; inset: 0;
-  background: rgba(0,0,0,0.45);
-  display: flex; align-items: center; justify-content: center;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   z-index: 1000;
 }
+
 .modal {
-  background: #fff; border-radius: 8px;
-  padding: 24px; max-width: 540px; width: 90%;
-  box-shadow: 0 10px 30px rgba(0,0,0,0.25);
+  background: #fff;
+  border-radius: 8px;
+  padding: 24px;
+  max-width: 540px;
+  width: 90%;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
 }
-.modal h4 { margin: 0 0 12px; font-size: 16px; color: #b91c1c; }
-.modal-missing-list { margin: 8px 0 12px; padding-left: 20px; font-size: 13px; }
-.modal-missing-list code { background: #f1f5f9; padding: 1px 5px; border-radius: 3px; }
-.modal-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 16px; }
+
+.modal h4 {
+  margin: 0 0 12px;
+  font-size: 16px;
+  color: #b91c1c;
+}
+
+.modal-missing-list {
+  margin: 8px 0 12px;
+  padding-left: 20px;
+  font-size: 13px;
+}
+
+.modal-missing-list code {
+  background: #f1f5f9;
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
 
 .change-password-modal {
   max-width: 460px;
@@ -1978,7 +2021,7 @@ body,
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  box-shadow: var(--shadow-lg, 0 4px 12px rgba(0,0,0,0.15));
+  box-shadow: var(--shadow-lg, 0 4px 12px rgba(0, 0, 0, 0.15));
   min-width: 160px;
   overflow: hidden;
 }
@@ -2219,7 +2262,7 @@ body,
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  box-shadow: var(--shadow-lg, 0 4px 12px rgba(0,0,0,0.15));
+  box-shadow: var(--shadow-lg, 0 4px 12px rgba(0, 0, 0, 0.15));
   max-height: 200px;
   overflow-y: auto;
 }


### PR DESCRIPTION
## 摘要

本 PR 主要调整了前端页面中左侧菜单栏的样式，使其始终占据窗口高度，不随着右侧内容高度的变化而变化。

Closes #76 

## 范围

- [x] 本 PR 保持小而聚焦。
- [x] 本 PR 没有把无关重构、纯格式化改动或翻译工作混入功能改动。
- [x] 公开 API、数据模型、权限、安全边界和部署行为没有变化；如有变化，已
      在下方说明影响。

## 截图或录屏

改动后的侧栏如下图所示，不再因为右侧页面过长而拉高高度。
<img width="2560" height="1528" alt="图片" src="https://github.com/user-attachments/assets/91d06d13-dd63-49aa-b7d9-4f78d9f0048f" />

## 迁移 / 配置影响

 `N/A`

## 验证

- [x] `cd src/backend && uv run python -m pytest tests/ -v`
- [x] `cd src/frontend && npm test`
- [x] `cd src/frontend && npm run build`

## 检查清单

- [x] 改动范围清晰且聚焦。
- [x] 已按需关联相关 Issue。
- [x] 如果行为、API 形状或配置发生变化，已同步更新文档。
- [x] 没有引入密钥、私有 URL 或个人本机路径。
