### PR TITLE
fix(ci): skip CodeQL gate wait on Dependabot PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,6 +57,9 @@ jobs:
             const isForkPullRequest = Boolean(
               pullRequest && pullRequest.head.repo.full_name !== pullRequest.base.repo.full_name,
             );
+            const isDependabotPullRequest = Boolean(
+              pullRequest && pullRequest.user?.login === 'dependabot[bot]',
+            );
             const requiredChecks = [];
 
             if (process.env.JS_CHANGED === 'true') {
@@ -77,6 +80,13 @@ jobs:
             if (isForkPullRequest) {
               core.info(
                 `Skipping CodeQL gate for fork pull request ${pullRequest.number}; GitHub-managed CodeQL analyze checks are not emitted for this context.`,
+              );
+              return;
+            }
+
+            if (isDependabotPullRequest) {
+              core.info(
+                `Skipping CodeQL gate for Dependabot pull request ${pullRequest.number}; GitHub-managed CodeQL default setup does not run Analyze on Dependabot-authored PRs.`,
               );
               return;
             }


### PR DESCRIPTION
## Summary

- `CodeQL Required` 在检测到 `src/backend/**` / `src/frontend/**` / `.github/workflows/**` 变化时会轮询 `Analyze (...)` check runs，但 GitHub-managed CodeQL default setup **不会**在 Dependabot 创建的 PR 上发起 Analyze。结果 gate 永远等不到 check 出现，15 分钟后超时失败（参见 #120 的运行日志）。
- 在 gate 脚本里加一个 Dependabot 判定分支，参照现有 fork PR 的处理方式，识别到 `dependabot[bot]` 作者后直接放行并记录原因。
- 不改变其它 PR 的行为；非 Dependabot PR 仍按原逻辑轮询所需的 Analyze check。

## Test plan

- [ ] 等下一个 Dependabot 升级 PR 上 `CodeQL Required` 直接通过，且日志里出现 `Skipping CodeQL gate for Dependabot pull request ...`
- [ ] 在一个普通分支 PR 上确认 gate 仍正常轮询 `Analyze (python)` / `Analyze (javascript-typescript)` / `Analyze (actions)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)