### PR TITLE
docs: add process template examples

### DIFF
--- a/src/backend/tests/test_process_template_examples.py
+++ b/src/backend/tests/test_process_template_examples.py
@@ -1,0 +1,22 @@
+import json
+import unittest
+from pathlib import Path
+
+from routers.process_templates import validate_template_json
+
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[3] / "templates"
+
+
+class ProcessTemplateExamplesTestCase(unittest.TestCase):
+    def test_all_example_templates_match_current_schema(self):
+        template_paths = sorted(TEMPLATES_DIR.glob("*.json"))
+        self.assertTrue(template_paths, "templates/ must contain at least one JSON example")
+
+        for template_path in template_paths:
+            with self.subTest(template=template_path.name):
+                data = json.loads(template_path.read_text(encoding="utf-8"))
+                normalized_json, slots, normalized_data = validate_template_json(data)
+
+                self.assertEqual(json.loads(normalized_json), normalized_data)
+                self.assertTrue(slots)

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,48 @@
+# HALF 流程模板示例
+
+本目录提供可复用的流程模板 JSON，帮助用户从常见协作流程开始使用 HALF，
+而不必从空白模板设计任务 DAG。
+
+## 示例列表
+
+| 文件 | 场景 | 协作方式 |
+|---|---|---|
+| [`bug-fix-with-dual-review.json`](./bug-fix-with-dual-review.json) | 复现、修复并验证一个 Bug | 一个 Agent 负责修复，两个 Agent 并行测试和评审 |
+| [`feature-development-with-dual-review.json`](./feature-development-with-dual-review.json) | 设计、实现并验收一个功能 | 一个 Agent 负责开发，两个 Agent 并行验收和评审 |
+
+两个示例均采用 `1+2` 协作方式：`agent-1` 负责主要工作，`agent-2` 和
+`agent-3` 在主任务完成后从不同角度独立检查，最后由 `agent-1` 汇总结论并
+完成交付。使用模板时，需要将这些槽位分别绑定到项目中可用的 Agent。
+
+## 使用方法
+
+HALF 当前不支持直接从文件导入模板，需要手动复制 JSON：
+
+1. 打开需要使用的 `.json` 文件并复制完整内容。
+2. 在 HALF 中进入“流程模板”，选择“新建流程模板”。
+3. 将内容粘贴到“模板 JSON”输入框，点击“预览 JSON”。
+4. 检查自动填充的模板名称、描述、Agent 角色和任务 DAG。
+5. 根据项目需要调整任务描述和角色说明，然后保存模板。
+
+示例文件只对应创建页面中的“模板 JSON”字段。必需输入等其他字段需要在
+页面中单独配置。
+
+## 贡献新模板
+
+新增模板时，请保持一个文件只描述一种明确的协作流程，并满足以下要求：
+
+- 文件名使用小写英文和连字符，扩展名为 `.json`。
+- `tasks` 非空，且每个 `task_code` 在模板内唯一。
+- `task_name` 和 `description` 清楚说明任务目标与交付要求。
+- `assignee` 使用 `agent-N` 槽位，不绑定具体 Agent。
+- `depends_on` 只引用模板内已有任务，并保持任务图无环。
+- `expected_output` 使用仓库内相对路径，例如
+  `outputs/TASK-001/result.json`。
+- 在本文件的示例列表中补充模板用途和协作方式。
+
+提交前运行后端测试，确认所有示例都能通过当前模板 schema 校验：
+
+```bash
+cd src/backend
+uv run pytest tests/test_process_template_examples.py -v
+```

--- a/templates/bug-fix-with-dual-review.json
+++ b/templates/bug-fix-with-dual-review.json
@@ -1,0 +1,69 @@
+{
+  "plan_name": "Bug 修复与双 Agent 验证",
+  "description": "适用于可复现的 Bug：一个 Agent 完成定位和修复，两个 Agent 分别进行功能验证和代码评审，最后统一收敛并交付。",
+  "agent_roles": [
+    {
+      "slot": "agent-1",
+      "description": "修复 Agent，负责复现问题、定位根因、实现修复、自测并根据验证意见完成最终交付。"
+    },
+    {
+      "slot": "agent-2",
+      "description": "测试 Agent，负责独立复现原问题并执行针对性测试与回归测试。"
+    },
+    {
+      "slot": "agent-3",
+      "description": "评审 Agent，负责独立审查根因分析、代码改动、测试覆盖和潜在回归风险。"
+    }
+  ],
+  "tasks": [
+    {
+      "task_code": "BUG-001",
+      "task_name": "复现问题并定位根因",
+      "description": "根据项目目标和问题描述复现 Bug，记录环境、复现步骤、实际行为与预期行为，定位根因并提出范围明确的修复方案。",
+      "assignee": "agent-1",
+      "depends_on": [],
+      "expected_output": "outputs/BUG-001/result.json"
+    },
+    {
+      "task_code": "BUG-002",
+      "task_name": "实现修复并完成自测",
+      "description": "依据根因分析实现最小范围修复，补充能够防止回归的测试，运行相关测试与静态检查，并记录改动和验证结果。",
+      "assignee": "agent-1",
+      "depends_on": [
+        "BUG-001"
+      ],
+      "expected_output": "outputs/BUG-002/result.json"
+    },
+    {
+      "task_code": "BUG-003",
+      "task_name": "独立功能与回归测试",
+      "description": "基于问题描述和修复结果独立验证原问题已解决，检查关键相邻功能，记录测试环境、执行步骤、结果和发现的问题。",
+      "assignee": "agent-2",
+      "depends_on": [
+        "BUG-002"
+      ],
+      "expected_output": "outputs/BUG-003/result.json"
+    },
+    {
+      "task_code": "BUG-004",
+      "task_name": "独立代码评审",
+      "description": "审查根因是否成立、修复是否完整、测试是否覆盖失败路径，并检查安全性、兼容性和潜在回归；只报告有证据且可执行的问题。",
+      "assignee": "agent-3",
+      "depends_on": [
+        "BUG-002"
+      ],
+      "expected_output": "outputs/BUG-004/result.json"
+    },
+    {
+      "task_code": "BUG-005",
+      "task_name": "收敛验证意见并交付",
+      "description": "汇总测试和评审结论，处理确认有效的问题，重新运行必要检查，并输出最终改动摘要、验证证据、遗留风险和交付位置。",
+      "assignee": "agent-1",
+      "depends_on": [
+        "BUG-003",
+        "BUG-004"
+      ],
+      "expected_output": "outputs/BUG-005/result.json"
+    }
+  ]
+}

--- a/templates/feature-development-with-dual-review.json
+++ b/templates/feature-development-with-dual-review.json
@@ -1,0 +1,69 @@
+{
+  "plan_name": "功能开发与双 Agent 验收",
+  "description": "适用于边界清楚的功能开发：一个 Agent 完成设计和实现，两个 Agent 分别进行需求验收和工程评审，最后统一收敛并交付。",
+  "agent_roles": [
+    {
+      "slot": "agent-1",
+      "description": "开发 Agent，负责澄清需求、设计方案、实现功能、补充测试并根据验收意见完成最终交付。"
+    },
+    {
+      "slot": "agent-2",
+      "description": "验收 Agent，负责从用户目标和验收标准出发独立验证功能行为与异常路径。"
+    },
+    {
+      "slot": "agent-3",
+      "description": "工程评审 Agent，负责独立审查设计合理性、代码质量、测试覆盖、兼容性和维护成本。"
+    }
+  ],
+  "tasks": [
+    {
+      "task_code": "FEAT-001",
+      "task_name": "澄清需求并设计方案",
+      "description": "梳理功能目标、约束、非目标和验收标准，分析现有实现与影响范围，形成可执行的设计和测试计划；未解决的关键歧义应明确列出。",
+      "assignee": "agent-1",
+      "depends_on": [],
+      "expected_output": "outputs/FEAT-001/result.json"
+    },
+    {
+      "task_code": "FEAT-002",
+      "task_name": "实现功能并完成自测",
+      "description": "按照已确认的设计实现功能，补充正常、边界和失败路径测试，运行相关测试与构建检查，并记录重要实现决策和验证结果。",
+      "assignee": "agent-1",
+      "depends_on": [
+        "FEAT-001"
+      ],
+      "expected_output": "outputs/FEAT-002/result.json"
+    },
+    {
+      "task_code": "FEAT-003",
+      "task_name": "独立需求验收",
+      "description": "依据功能目标和验收标准独立检查完整用户流程、边界输入和失败反馈，记录可复现的验证步骤、结果及未满足的要求。",
+      "assignee": "agent-2",
+      "depends_on": [
+        "FEAT-002"
+      ],
+      "expected_output": "outputs/FEAT-003/result.json"
+    },
+    {
+      "task_code": "FEAT-004",
+      "task_name": "独立工程评审",
+      "description": "审查实现是否符合现有架构和项目约定，检查正确性、安全性、兼容性、测试覆盖和后续维护成本；只报告有证据且可执行的问题。",
+      "assignee": "agent-3",
+      "depends_on": [
+        "FEAT-002"
+      ],
+      "expected_output": "outputs/FEAT-004/result.json"
+    },
+    {
+      "task_code": "FEAT-005",
+      "task_name": "收敛验收意见并交付",
+      "description": "汇总需求验收和工程评审结论，处理确认有效的问题，重新运行必要检查，并输出最终功能摘要、验证证据、已知限制和交付位置。",
+      "assignee": "agent-1",
+      "depends_on": [
+        "FEAT-003",
+        "FEAT-004"
+      ],
+      "expected_output": "outputs/FEAT-005/result.json"
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

- 新增 `templates/` 示例目录及使用、贡献说明
- 提供 bug 修复和功能开发两份双评审工作流模板
- 新增回归测试，确保示例持续通过现有 process template schema 校验

## 验证

- `uv run pytest`: 275 passed, 99 subtests passed

Closes #30